### PR TITLE
Create a 0.4.x-dev image targeting expected upgrades

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,11 @@ RUN <<EOF
   wget -O /usr/libexec/docker/cli-plugins/docker-compose "https://github.com/docker/compose/releases/download/v${COMPOSE_VERSION}/docker-compose-linux-$(uname -m)"
   chmod +x  /usr/libexec/docker/cli-plugins/docker-compose
 
+  # docker compose v2 standalone alias
+  if [ "$COMPOSE_V1_INSTALL" != yes ]; then
+    ln -s /usr/libexec/docker/cli-plugins/docker-compose /usr/bin/docker-compose
+  fi
+
   # helm2
   wget -O helm.tar.gz "https://get.helm.sh/helm-v2.17.0-linux-${TARGETARCH}.tar.gz"
   tar -C /usr/local/bin --strip-components=1 -zxvf helm.tar.gz "linux-${TARGETARCH}/helm"
@@ -141,6 +146,11 @@ RUN <<EOF
   mkdir -p /usr/libexec/docker/cli-plugins
   curl --silent --show-error --fail --location -o /usr/libexec/docker/cli-plugins/docker-compose "https://github.com/docker/compose/releases/download/v${COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)"
   chmod +x  /usr/libexec/docker/cli-plugins/docker-compose
+
+  # docker compose v2 standalone alias
+  if [ "$COMPOSE_V1_INSTALL" != yes ]; then
+    ln -s /usr/libexec/docker/cli-plugins/docker-compose /usr/bin/docker-compose
+  fi
 
   DEBIAN_FRONTEND=noninteractive apt-get -qq -y --no-install-recommends install \
     apt-transport-https ca-certificates curl gnupg

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,7 @@ FROM docker/buildx-bin:$BUILDX_VERSION as buildx
 FROM php:${PHP_MAJOR_VERSION}-cli-alpine${ALPINE_VERSION} as alpine
 ARG TARGETARCH
 ARG COMPOSE_VERSION
+ARG COMPOSE_V1_INSTALL=no
 ARG HELM_VERSION
 ARG KUBESEAL_VERSION
 
@@ -61,7 +62,7 @@ RUN <<EOF
     aws-cli \
     bash \
     docker-cli \
-    docker-compose \
+    $([ "$COMPOSE_V1_INSTALL" != yes ] || docker-compose) \
     git \
     grep \
     jq \
@@ -109,6 +110,7 @@ ENTRYPOINT [ "/usr/local/bin/ws" ]
 FROM php:${PHP_MAJOR_VERSION}-cli-buster as buster
 ARG TARGETARCH
 ARG COMPOSE_VERSION
+ARG COMPOSE_V1_INSTALL=no
 ARG HELM_VERSION
 ARG KUBESEAL_VERSION
 
@@ -123,14 +125,16 @@ RUN <<EOF
   apt-get update -qq
 
   # docker compose v1
-  if [ "$TARGETARCH" = amd64 ]; then
-    curl --silent --show-error --fail --location "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-linux-$(uname -m)" -o /usr/local/bin/docker-compose
-    chmod +x /usr/local/bin/docker-compose
-  else
-    DEBIAN_FRONTEND=noninteractive apt-get -qq -y --no-install-recommends install \
-      python3-bcrypt python3-cryptography python3-pip python3-setuptools python3-dev python3-nacl python3-wheel libffi-dev
-    pip3 install docker-compose
-    apt-get remove -qq -y python3-setuptools python3-dev
+  if [ "$COMPOSE_V1_INSTALL" = yes ]; then
+    if [ "$TARGETARCH" = amd64 ]; then
+      curl --silent --show-error --fail --location "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-linux-$(uname -m)" -o /usr/local/bin/docker-compose
+      chmod +x /usr/local/bin/docker-compose
+    else
+      DEBIAN_FRONTEND=noninteractive apt-get -qq -y --no-install-recommends install \
+        python3-bcrypt python3-cryptography python3-pip python3-setuptools python3-dev python3-nacl python3-wheel libffi-dev
+      pip3 install docker-compose
+      apt-get remove -qq -y python3-setuptools python3-dev
+    fi
   fi
 
   # docker compose v2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,15 @@
 services:
+  0.4.x:
+    build:
+      context: .
+      target: alpine
+      args:
+        WS_VERSION: 0.4.x
+        PHP_MAJOR_VERSION: '8.2'
+        ALPINE_VERSION: '3.18'
+      x-bake:
+        tags:
+          - quay.io/inviqa_images/workspace:0.4.x-dev
   0.3.x:
     build:
       context: .
@@ -7,6 +18,7 @@ services:
         WS_VERSION: 0.3.x
         PHP_MAJOR_VERSION: '8.1'
         ALPINE_VERSION: '3.17'
+        COMPOSE_V1_INSTALL: 'yes'
       x-bake:
         tags:
           - quay.io/inviqa_images/workspace:0.3.x-dev
@@ -19,6 +31,7 @@ services:
         WS_VERSION: 0.2.x
         PHP_MAJOR_VERSION: '8.0'
         ALPINE_VERSION: '3.16'
+        COMPOSE_V1_INSTALL: 'yes'
       x-bake:
         tags:
           - quay.io/inviqa_images/workspace:0.2.x-dev
@@ -31,6 +44,7 @@ services:
         WS_VERSION: 0.2.x
         PHP_MAJOR_VERSION: '8.0'
         ALPINE_VERSION: '3.16'
+        COMPOSE_V1_INSTALL: 'yes'
       x-bake:
         tags:
           - quay.io/inviqa_images/workspace:0.2.x-dev-buster


### PR DESCRIPTION
Removing docker compose v1 support for that version onwards

Avoid tagging as latest until targets met