### PR TITLE
Switch 0.3.x to use docker-compose v2 standalone

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,6 @@ services:
         WS_VERSION: 0.3.x
         PHP_MAJOR_VERSION: '8.1'
         ALPINE_VERSION: '3.17'
-        COMPOSE_V1_INSTALL: 'yes'
       x-bake:
         tags:
           - quay.io/inviqa_images/workspace:0.3.x-dev


### PR DESCRIPTION
docker-compose v1 is looking a bit unstable and all projects should be using v2 now